### PR TITLE
Feature/parameters optionality harmonization

### DIFF
--- a/src/Console/Base/BaseCommand.cs
+++ b/src/Console/Base/BaseCommand.cs
@@ -7,7 +7,7 @@ namespace Cmf.CustomerPortal.Sdk.Console.Base
     {
         protected BaseCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option(new[] { "--verbose", "-v" }, Resources.VERBOSE_HELP));
+            Add(new Option<bool>(new[] { "--verbose", "-v" }, Resources.VERBOSE_HELP));
         }
 
         protected ISession CreateSession(bool verbose)

--- a/src/Console/CheckAgentConnectionCommand.cs
+++ b/src/Console/CheckAgentConnectionCommand.cs
@@ -15,7 +15,10 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CheckAgentConnectionCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--agent-name", "--name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP));
+            Add(new Option<string>(new[] { "--agent-name", "--name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP)
+            {
+                IsRequired = true
+            });
 
             Handler = CommandHandler.Create(typeof(CheckAgentConnectionCommand).GetMethod(nameof(CheckAgentConnectionCommand.CheckAgentConnectionHandler)), this);
         }

--- a/src/Console/Console.csproj
+++ b/src/Console/Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>Cmf.CustomerPortal.Sdk.Console</AssemblyName>
+    <AssemblyName>cmf-portal-sdk</AssemblyName>
     <RootNamespace>Cmf.CustomerPortal.Sdk.Console</RootNamespace>
   </PropertyGroup>
 

--- a/src/Console/CreateInfrastructureFromTemplateCommand.cs
+++ b/src/Console/CreateInfrastructureFromTemplateCommand.cs
@@ -15,10 +15,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CreateInfrastructureFromTemplateCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP)
-            {
-                IsRequired = true
-            });
+            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
             Add(new Option<string>(new[] { "--template-name", "-t" }, Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP)
             {
                 IsRequired = true

--- a/src/Console/DeployCommand.cs
+++ b/src/Console/DeployCommand.cs
@@ -57,7 +57,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
             Add(new Option<DirectoryInfo>(new string[] { "--output", "-o" }, Resources.DEPLOYMENT_OUTPUTDIR_HELP));
 
-            Add(new Option(new[] { "--interactive", "-i" }, Resources.DEPLOYMENT_OUTPUTDIR_HELP));
+            Add(new Option<bool>(new[] { "--interactive", "-i" }, Resources.DEPLOYMENT_OUTPUTDIR_HELP));
 
             Handler = CommandHandler.Create(typeof(DeployCommand).GetMethod(nameof(DeployCommand.DeployHandler)), this);
         }

--- a/src/Console/PublishCommand.cs
+++ b/src/Console/PublishCommand.cs
@@ -17,7 +17,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public PublishCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option(new string[] { "--path", "-p" }, Resources.PUBLISHMANIFESTS_PATH_HELP)
+            Add(new Option<FileSystemInfo>(new string[] { "--path", "-p" }, Resources.PUBLISHMANIFESTS_PATH_HELP)
             {
                 Argument = new Argument<FileSystemInfo>().ExistingOnly(),
                 IsRequired = true

--- a/src/Powershell/NewEnvironment.cs
+++ b/src/Powershell/NewEnvironment.cs
@@ -22,10 +22,9 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         public FileInfo ParametersPath { get; set; }
 
         [Parameter(
-            HelpMessage = Resources.DEPLOYMENT_ENVIRONMENTTYPE_HELP,
-            Mandatory = true
+            HelpMessage = Resources.DEPLOYMENT_ENVIRONMENTTYPE_HELP
         )]
-        public EnvironmentType EnvironmentType { get; set; }
+        public EnvironmentType EnvironmentType { get; set; } = EnvironmentType.Development;
 
         [Parameter(
             HelpMessage = Resources.DEPLOYMENT_SITE_HELP,

--- a/src/Powershell/NewInfrastructureFromTemplate.cs
+++ b/src/Powershell/NewInfrastructureFromTemplate.cs
@@ -20,7 +20,8 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         public string AgentName { get; set; }
 
         [Parameter(
-            HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP
+            HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP,
+            Mandatory = true
         )]
         public string TemplateName { get; set; }
 


### PR DESCRIPTION
- Console tool renamed from `Cmf.CustomerPortal.Sdk.Console` to `cmf-portal-sdk` in order to be supported by the cmf cli
- Harmonization of parameters optionality between console tool and powershell. Changes performed:
  - `checkagentconnection` / `Get-AgentConnection`:
    - `name` is mandatory
  - `createinfrastructurefromtemplate` / `New-InfrastructureFromTemplate`:
    - `template-name` is mandatory
    - `name` and `agent-name` are optional
  - `deploy` / `New-Environment`:
    - `parameters` is optional
    - `type` is optional, with default value **Development**