### PR TITLE
SDK console tool renamed. NPM package automatically published on release creation.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,3 +66,13 @@ jobs:
           args: Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Publish NPM package (if pre-release)
+      - run: cd npm && npm publish --tag next
+        if: "github.event.release.prerelease"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Publish NPM package (if regular release)
+      - run: cd npm && npm publish --tag latest
+        if: "!github.event.release.prerelease"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -64,6 +64,9 @@ jobs:
           args: Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Replace Version token on NPM package.json
+      - name: Replace package.json Version token
+        run: cd npm && sed -i ''s/#{Version}#/${{ steps.getver.outputs.result }}/g'' package.json
       # Publish NPM package (if pre-release)
       - run: cd npm && npm publish --tag next
         if: "github.event.release.prerelease"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,68 @@
+name: Publish NPM Package on Release
+
+on:
+  release:
+    types: [created]
+
+  workflow_dispatch:
+
+jobs:
+  BuildAndPublish:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Git checkout
+        uses: actions/checkout@v2
+      # Needs .NET
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+      # Run build
+      - name: Build Windows
+        env:
+          DOTNET_CLI_TELEMETRY_OPTOUT: true
+        run: dotnet publish --configuration Release --self-contained --runtime win-x64 Cmf.CustomerPortal.Sdk.sln
+      - name: Build Linux
+        env:
+          DOTNET_CLI_TELEMETRY_OPTOUT: true
+        run: dotnet publish --configuration Release --self-contained --runtime linux-x64 Cmf.CustomerPortal.Sdk.sln
+      # Read version
+      - name: Read tool version
+        uses: QwerMike/xpath-action@v1
+        id: getver
+        with:
+          filename: src/Version.props
+          expression: '/Project/PropertyGroup/Version/text()'
+      # Needs zip
+      - name: Install zip
+        uses: montudor/action-zip@v0.1.0
+      # Archive
+      - name: Archive Console Win64
+        run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64.zip .
+        working-directory: src/Console/bin/Release/netcoreapp3.1/win-x64/publish/
+      - name: Archive Console Linux64
+        run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.linux-x64.zip .
+        working-directory: src/Console/bin/Release/netcoreapp3.1/linux-x64/publish/
+      - name: Archive PowerShell
+        run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip .
+        working-directory: src/Powershell/bin/Release/netstandard2.0/linux-x64/publish/
+      - run: pwd && ls -la && echo ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish win-x64 to release
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish linux-x64 to release
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.linux-x64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish PowerShell to release
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,8 +4,6 @@ on:
   release:
     types: [created]
 
-  workflow_dispatch:
-
 jobs:
   BuildAndPublish:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -37,7 +37,7 @@ jobs:
       # Needs zip
       - name: Install zip
         uses: montudor/action-zip@v0.1.0
-      # Archive
+      # Generate packs
       - name: Archive Console Win64
         run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64.zip .
         working-directory: src/Console/bin/Release/netcoreapp3.1/win-x64/publish/
@@ -47,20 +47,20 @@ jobs:
       - name: Archive PowerShell
         run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip .
         working-directory: src/Powershell/bin/Release/netstandard2.0/linux-x64/publish/
-      - run: pwd && ls -la && echo ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish win-x64 to release
+      # Add to release assets
+      - name: Add Console Win64 to Release assets
         uses: JasonEtco/upload-to-release@master
         with:
           args: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish linux-x64 to release
+      - name: Add Console Linux64 to Release assets
         uses: JasonEtco/upload-to-release@master
         with:
           args: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.linux-x64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish PowerShell to release
+      - name: Add PowerShell to Release assets
         uses: JasonEtco/upload-to-release@master
         with:
           args: Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip

--- a/npm/install.js
+++ b/npm/install.js
@@ -27,7 +27,7 @@ const installScriptLocation = path.resolve(node_modules(process.env.npm_package_
 // delete empty cmf-sdk;
 // this file must exist during npm install so the bin link is created;
 // it will be replaced by the downloaded binary
-fs.rm(path.join(installScriptLocation, 'cmf-sdk'), { force: true, recursive: true }, (err) => {
+fs.unlink(path.join(installScriptLocation, 'cmf-sdk'), (err) => {
     if (err) {
         // File deletion failed
         console.error(err.message);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require('path'),
+      fs = require('fs'),
+      axios = require('axios'),
+      AdmZip = require("adm-zip"),
+      tmp = require('tmp'),
+      node_modules = require('node_modules-path');
+
+// Mapping from Node's `process.arch` to dotnet's `RID`
+const ARCH_MAPPING = {
+    "ia32": "x86",
+    "x64": "x64",
+};
+// Mapping between Node's `process.platform` to dotnet's RID
+const PLATFORM_MAPPING = {
+    "darwin": "osx",
+    "linux": "linux",
+    "win32": "win"
+};
+
+
+const installScriptLocation = path.resolve(node_modules(process.env.npm_package_name), process.env.npm_package_name, 'bin');
+
+// delete empty cmf-sdk;
+// this file must exist during npm install so the bin link is created;
+// it will be replaced by the downloaded binary
+fs.rm(path.join(installScriptLocation, 'cmf-sdk'), { force: true, recursive: true }, (err) => {
+    if (err) {
+        // File deletion failed
+        console.error(err.message);
+        process.exit(1);
+    }
+});
+
+// download respective release zip from github
+console.info(`Current platform / arch: ${process.platform} / ${process.arch}`);
+const pkgUrl = `https://github.com/criticalmanufacturing/portal-sdk/releases/download/${process.env.npm_package_version}/Cmf.CustomerPortal.Sdk.Console-${process.env.npm_package_version}.${PLATFORM_MAPPING[process.platform]}-${ARCH_MAPPING[process.arch]}.zip`;// opts.binUrl.replace("{{version}}", opts.version).replace("{{platform}}", PLATFORM_MAPPING[process.platform]).replace("{{arch}}", ARCH_MAPPING[process.arch]);
+console.info(`Getting release archive from ${pkgUrl} into ${path.resolve(installScriptLocation)}`);
+axios.get(pkgUrl, { responseType: 'arraybuffer' })
+     .then(function (response) {
+         // handle success
+         const zip = tmp.tmpNameSync();
+         console.log(`Writing temporary zip file to ${zip}`);
+         fs.writeFileSync(zip, response.data);
+         console.log(`Extracting zip file ${zip} to ${installScriptLocation}`);
+         (new AdmZip(zip)).extractAllTo(installScriptLocation);
+     })
+     .catch(function (error) {
+         // handle error
+         console.error(error);
+         console.error(error(`Could not install version ${process.env.npm_package_version} on your platform ${process.platform}/${process.arch}: ${e.message}`));
+         process.exit(1);
+     });

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "@criticalmanufacturing/sdk",
+    "version": "1.1.2",
+    "description": "Critical Manufacturing CLI SDK",
+    "author": "Critical Manufacturing, SA",
+    "keywords": [
+        "cmf"
+    ],
+    "license": "BSD-3-Clause",
+    "homepage": "https://github.com/criticalmanufacturing/portal-sdk#readme",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/criticalmanufacturing/portal-sdk.git"
+    },
+    "bugs": {
+        "url": "https://github.com/criticalmanufacturing/portal-sdk/issues"
+    },
+    "bin": {
+        "cmf-portal-sdk": "./bin/cmf-portal-sdk"
+    },
+    "scripts": {
+        "postinstall": "node install.js"
+    },
+    "os": [
+        "win32",
+        "linux"
+    ],
+    "cpu": [
+        "x64"
+    ],
+    "dependencies": {
+        "@criticalmanufacturing/cli": "*",
+        "adm-zip": "^0.5.5",
+        "axios": "^0.21.1",
+        "node_modules-path": "^2.0.5"
+    }
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -16,7 +16,7 @@
         "url": "https://github.com/criticalmanufacturing/portal-sdk/issues"
     },
     "bin": {
-        "cmf-portal-sdk": "./bin/cmf-portal-sdk"
+        "cmf-sdk": "./bin/cmf-sdk"
     },
     "scripts": {
         "postinstall": "node install.js"
@@ -32,6 +32,7 @@
         "@criticalmanufacturing/cli": "*",
         "adm-zip": "^0.5.5",
         "axios": "^0.21.1",
-        "node_modules-path": "^2.0.5"
+        "node_modules-path": "^2.0.5",
+        "tmp": "^0.2.1"
     }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@criticalmanufacturing/sdk",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Critical Manufacturing CLI SDK",
     "author": "Critical Manufacturing, SA",
     "keywords": [

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@criticalmanufacturing/sdk",
-    "version": "1.1.3",
+    "version": "#{Version}#",
     "description": "Critical Manufacturing CLI SDK",
     "author": "Critical Manufacturing, SA",
     "keywords": [

--- a/npm/package.json
+++ b/npm/package.json
@@ -29,7 +29,6 @@
         "x64"
     ],
     "dependencies": {
-        "@criticalmanufacturing/cli": "*",
         "adm-zip": "^0.5.5",
         "axios": "^0.21.1",
         "node_modules-path": "^2.0.5",

--- a/src/Console/Console.csproj
+++ b/src/Console/Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>cmf-portal-sdk</AssemblyName>
+    <AssemblyName>cmf-sdk</AssemblyName>
     <RootNamespace>Cmf.CustomerPortal.Sdk.Console</RootNamespace>
   </PropertyGroup>
 

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Console tool renamed from `cmf-portal-sdk` to `cmf-sdk`.
- Added package.json to allow NPM package creation. This will, on the package installation, download the correct release binaries and extract them, so them can be accessible by the CMF CLI.
- Created a github workflow that, when a release is created, automatically compiles the release assets, and publishes the new package to npmjs.com