### PR TITLE
fix(): changeset not being implicit for new versions

### DIFF
--- a/src/Common/Handlers/NewEnvironmentHandler.cs
+++ b/src/Common/Handlers/NewEnvironmentHandler.cs
@@ -84,6 +84,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
                 environment.CustomerLicense = await _customerPortalClient.GetObjectByName<CustomerLicense>(licenseName);
                 environment.DeploymentTarget = GetTargetValue(target);
                 environment.Parameters = rawParameters;
+                environment.ChangeSet = null;
             }
             // if not, just build a new complete object and create it
             else


### PR DESCRIPTION
ChangeSet was being reused between versions. This was ok before maintaining the CustomerEnvironments in state Created because it was being terminated after each approval. 