### PR TITLE
feat: add cmf-cli-plugin keyword for CLI plugin search

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -4,7 +4,8 @@
     "description": "Critical Manufacturing Portal CLI",
     "author": "Critical Manufacturing, SA",
     "keywords": [
-        "cmf"
+        "cmf",
+        "cmf-cli-plugin"
     ],
     "license": "BSD-3-Clause",
     "homepage": "https://github.com/criticalmanufacturing/portal-sdk#readme",


### PR DESCRIPTION
We have a search functionality for plugins on the CLI roadmap, which requires all plugins to ship with the `cmf-cli-plugin` keyword.