### PR TITLE
72705 - Portal SDK fails when installing a customer environment with spaces on the name

### DIFF
--- a/src/Common/Resources.cs
+++ b/src/Common/Resources.cs
@@ -4,7 +4,8 @@
     {
         public const string LOGIN_PAT_HELP = "Personal Access Token used to access the Customer Portal";
 
-        public const string DEPLOYMENT_NAME_HELP = "Name of the new Customer Environment";
+        public const string DEPLOYMENT_NAME_HELP = "Name of the new Customer Environment. --name is also supported";
+        public const string DEPLOYMENT_ALIAS_HELP = "Command Alias";
         public const string DEPLOYMENT_DESCRIPTION_HELP = "Description of the new Customer Environment";
         public const string DEPLOYMENT_PARAMETERSPATH_HELP = "Path to parameters file that describes the Customer Environment";
         public const string DEPLOYMENT_ENVIRONMENTTYPE_HELP = "Type of the Customer Environment to deploy";

--- a/src/Console/CheckAgentConnectionCommand.cs
+++ b/src/Console/CheckAgentConnectionCommand.cs
@@ -15,7 +15,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CheckAgentConnectionCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--agent-name", "--name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP)
+            Add(new Option<string>(new[] { "--id","--agent-name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP)
             {
                 IsRequired = true
             });

--- a/src/Console/CheckAgentConnectionCommand.cs
+++ b/src/Console/CheckAgentConnectionCommand.cs
@@ -15,21 +15,20 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CheckAgentConnectionCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--id","--agent-name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP)
+            Add(new Option<string>(new[] { "--name","--agent-name", "-n", }, Resources.GETAGENTCONNECTION_NAME_HELP)
             {
                 IsRequired = true
             });
 
-            Handler = CommandHandler.Create(typeof(CheckAgentConnectionCommand).GetMethod(nameof(CheckAgentConnectionCommand.CheckAgentConnectionHandler)), this);
+            Handler = CommandHandler.Create((DeployParameters x) => CheckAgentConnectionHandler(x));
         }
 
-        public async Task CheckAgentConnectionHandler(bool verbose, string agentName)
+        public async Task CheckAgentConnectionHandler(DeployParameters parameters)
         {
             // get GetAgentConnectionHandler and run it
-            CreateSession(verbose);
+            CreateSession(parameters.Verbose);
             GetAgentConnectionHandler getAgentConnectionHandler = ServiceLocator.Get<GetAgentConnectionHandler>();
-            bool result = await getAgentConnectionHandler.Run(agentName);
-
+            bool result = await getAgentConnectionHandler.Run(parameters.AgentName);
             System.Console.WriteLine(result);
         }
     }

--- a/src/Console/CreateInfrastructureCommand.cs
+++ b/src/Console/CreateInfrastructureCommand.cs
@@ -15,7 +15,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CreateInfrastructureCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
+            Add(new Option<string>(new[] { "--id", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
             Add(new Option<string>(new[] { "--agent-name", "-a" }, Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP));
 
             Add(new Option<string>(new[] { "--site", "-s", }, Resources.INFRASTRUCTURE_SITE_HELP)
@@ -31,12 +31,12 @@ namespace Cmf.CustomerPortal.Sdk.Console
             Handler = CommandHandler.Create(typeof(CreateInfrastructureCommand).GetMethod(nameof(CreateInfrastructureCommand.CreateInfrastructureHandler)), this);
         }
 
-        public async Task CreateInfrastructureHandler(bool verbose, string name, string agentName, string site, string domain)
+        public async Task CreateInfrastructureHandler(bool verbose, string id, string agentName, string site, string domain)
         {
             // get new environment handler and run it
             CreateSession(verbose);
             NewInfrastructureHandler handler = ServiceLocator.Get<NewInfrastructureHandler>();
-            await handler.Run(name, agentName, site, domain);
+            await handler.Run(id, agentName, site, domain);
         }
     }
 }

--- a/src/Console/CreateInfrastructureCommand.cs
+++ b/src/Console/CreateInfrastructureCommand.cs
@@ -15,7 +15,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CreateInfrastructureCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--id", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
+            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
             Add(new Option<string>(new[] { "--agent-name", "-a" }, Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP));
 
             Add(new Option<string>(new[] { "--site", "-s", }, Resources.INFRASTRUCTURE_SITE_HELP)
@@ -28,15 +28,15 @@ namespace Cmf.CustomerPortal.Sdk.Console
                 IsRequired = true
             });
 
-            Handler = CommandHandler.Create(typeof(CreateInfrastructureCommand).GetMethod(nameof(CreateInfrastructureCommand.CreateInfrastructureHandler)), this);
+            Handler = CommandHandler.Create((DeployParameters x) => CreateInfrastructureHandler(x));
         }
 
-        public async Task CreateInfrastructureHandler(bool verbose, string id, string agentName, string site, string domain)
+        public async Task CreateInfrastructureHandler(DeployParameters parameters)
         {
             // get new environment handler and run it
-            CreateSession(verbose);
+            CreateSession(parameters.Verbose);
             NewInfrastructureHandler handler = ServiceLocator.Get<NewInfrastructureHandler>();
-            await handler.Run(id, agentName, site, domain);
+            await handler.Run(parameters.Name, parameters.AgentName, parameters.Site, parameters.Domain);
         }
     }
 }

--- a/src/Console/CreateInfrastructureFromTemplateCommand.cs
+++ b/src/Console/CreateInfrastructureFromTemplateCommand.cs
@@ -15,22 +15,22 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CreateInfrastructureFromTemplateCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--id", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
+            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
             Add(new Option<string>(new[] { "--template-name", "-t" }, Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP)
             {
                 IsRequired = true
             });
             Add(new Option<string>(new[] { "--agent-name", "-a" }, Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP));
 
-            Handler = CommandHandler.Create(typeof(CreateInfrastructureFromTemplateCommand).GetMethod(nameof(CreateInfrastructureFromTemplateCommand.CreateInfrastructureFromTemplateHandler)), this);
+            Handler = CommandHandler.Create((DeployParameters x) => CreateInfrastructureFromTemplateHandler(x));
         }
 
-        public async Task CreateInfrastructureFromTemplateHandler(bool verbose, string id, string agentName, string templateName)
+        public async Task CreateInfrastructureFromTemplateHandler(DeployParameters parameters)
         {
             // get new environment handler and run it
-            CreateSession(verbose);
+            CreateSession(parameters.Verbose);
             NewInfrastructureFromTemplateHandler newInfrastructureFromTemplateHandler = ServiceLocator.Get<NewInfrastructureFromTemplateHandler>();
-            await newInfrastructureFromTemplateHandler.Run(id, templateName, agentName);
+            await newInfrastructureFromTemplateHandler.Run(parameters.Name, parameters.TemplateName, parameters.AgentName);
         }
     }
 }

--- a/src/Console/CreateInfrastructureFromTemplateCommand.cs
+++ b/src/Console/CreateInfrastructureFromTemplateCommand.cs
@@ -15,7 +15,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public CreateInfrastructureFromTemplateCommand(string name, string description = null) : base(name, description)
         {
-            Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
+            Add(new Option<string>(new[] { "--id", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
             Add(new Option<string>(new[] { "--template-name", "-t" }, Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP)
             {
                 IsRequired = true
@@ -25,12 +25,12 @@ namespace Cmf.CustomerPortal.Sdk.Console
             Handler = CommandHandler.Create(typeof(CreateInfrastructureFromTemplateCommand).GetMethod(nameof(CreateInfrastructureFromTemplateCommand.CreateInfrastructureFromTemplateHandler)), this);
         }
 
-        public async Task CreateInfrastructureFromTemplateHandler(bool verbose, string name, string agentName, string templateName)
+        public async Task CreateInfrastructureFromTemplateHandler(bool verbose, string id, string agentName, string templateName)
         {
             // get new environment handler and run it
             CreateSession(verbose);
             NewInfrastructureFromTemplateHandler newInfrastructureFromTemplateHandler = ServiceLocator.Get<NewInfrastructureFromTemplateHandler>();
-            await newInfrastructureFromTemplateHandler.Run(name, templateName, agentName);
+            await newInfrastructureFromTemplateHandler.Run(id, templateName, agentName);
         }
     }
 }

--- a/src/Console/DeployAgentCommand.cs
+++ b/src/Console/DeployAgentCommand.cs
@@ -19,7 +19,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
         public DeployAgentCommand(string name, string description = null) : base(name, description)
         {
-            Handler = CommandHandler.Create(typeof(DeployAgentCommand).GetMethod(nameof(DeployAgentCommand.DeployHandler)), this);
+            Handler = CommandHandler.Create((DeployParameters x) => DeployHandler(x));
         }
 
         protected override IEnumerable<IOptionExtension> ExtendWithRange()
@@ -30,15 +30,14 @@ namespace Cmf.CustomerPortal.Sdk.Console
             return extensions;
         }
 
-        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string id, string description, FileInfo parameters, string type, string site, string license,
-            string package, string target, string templateName, DirectoryInfo output, string[] replaceTokens, bool interactive)
+        public async Task DeployHandler(DeployParameters parameters)
         {
             // get new environment handler and run it
-            CreateSession(verbose);
+            CreateSession(parameters.Verbose);
             NewEnvironmentHandler newEnvironmentHandler = ServiceLocator.Get<NewEnvironmentHandler>();
-            await newEnvironmentHandler.Run(id, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, null,
-                (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), target), output,
-                replaceTokens, interactive, customerInfrastructureName, description, templateName, false, true);
+            await newEnvironmentHandler.Run(parameters.Name, parameters.Parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), parameters.Type), parameters.Site, parameters.License, null,
+                (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), parameters.Target), parameters.Output,
+                parameters.ReplaceTokens, parameters.Interactive, parameters.CustomerInfrastructureName, parameters.Description, parameters.TemplateName, false, true);
         }
     }
 }

--- a/src/Console/DeployAgentCommand.cs
+++ b/src/Console/DeployAgentCommand.cs
@@ -30,13 +30,13 @@ namespace Cmf.CustomerPortal.Sdk.Console
             return extensions;
         }
 
-        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string name, string description, FileInfo parameters, string type, string site, string license,
+        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string id, string description, FileInfo parameters, string type, string site, string license,
             string package, string target, string templateName, DirectoryInfo output, string[] replaceTokens, bool interactive)
         {
             // get new environment handler and run it
             CreateSession(verbose);
             NewEnvironmentHandler newEnvironmentHandler = ServiceLocator.Get<NewEnvironmentHandler>();
-            await newEnvironmentHandler.Run(name, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, null,
+            await newEnvironmentHandler.Run(id, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, null,
                 (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), target), output,
                 replaceTokens, interactive, customerInfrastructureName, description, templateName, false, true);
         }

--- a/src/Console/DeployCommand.cs
+++ b/src/Console/DeployCommand.cs
@@ -32,7 +32,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
 
             Add(new Option<bool>(new[] { "--terminateOtherVersions", "-tov" }, Resources.DEPLOYMENT_TERMINATE_OTHER_VERSIONS_HELP));
 
-            Handler = CommandHandler.Create(typeof(DeployCommand).GetMethod(nameof(DeployCommand.DeployHandler)), this);
+            Handler = CommandHandler.Create((DeployParameters x) => DeployHandler(x));
         }
 
         protected override IEnumerable<IOptionExtension> ExtendWithRange()
@@ -45,15 +45,15 @@ namespace Cmf.CustomerPortal.Sdk.Console
             return extensions;
         }
 
-        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string id, string description, FileInfo parameters, string type, string site, string license,
-            string package, string target, string templateName, DirectoryInfo output, string[] replaceTokens, bool interactive, bool terminateOtherVersions)
+        public async Task DeployHandler(DeployParameters parameters)
         {
             // get new environment handler and run it
-            CreateSession(verbose);
+            CreateSession(parameters.Verbose);
             NewEnvironmentHandler newEnvironmentHandler = ServiceLocator.Get<NewEnvironmentHandler>();
-            await newEnvironmentHandler.Run(id, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, package,
-                (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), target), output,
-                replaceTokens, interactive, customerInfrastructureName, description, templateName, terminateOtherVersions, false);
+            await newEnvironmentHandler.Run(parameters.Name, parameters.Parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), parameters.Type), parameters.Site, parameters.License, 
+                parameters.Package,
+                (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), parameters.Target), parameters.Output,
+                parameters.ReplaceTokens, parameters.Interactive, parameters.CustomerInfrastructureName, parameters.Description, parameters.TemplateName, parameters.TerminateOtherVersions, false);
         }
     }
 }

--- a/src/Console/DeployCommand.cs
+++ b/src/Console/DeployCommand.cs
@@ -45,13 +45,13 @@ namespace Cmf.CustomerPortal.Sdk.Console
             return extensions;
         }
 
-        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string name, string description, FileInfo parameters, string type, string site, string license,
+        public async Task DeployHandler(bool verbose, string customerInfrastructureName, string id, string description, FileInfo parameters, string type, string site, string license,
             string package, string target, string templateName, DirectoryInfo output, string[] replaceTokens, bool interactive, bool terminateOtherVersions)
         {
             // get new environment handler and run it
             CreateSession(verbose);
             NewEnvironmentHandler newEnvironmentHandler = ServiceLocator.Get<NewEnvironmentHandler>();
-            await newEnvironmentHandler.Run(name, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, package,
+            await newEnvironmentHandler.Run(id, parameters, (EnvironmentType)Enum.Parse(typeof(EnvironmentType), type), site, license, package,
                 (DeploymentTarget)Enum.Parse(typeof(DeploymentTarget), target), output,
                 replaceTokens, interactive, customerInfrastructureName, description, templateName, terminateOtherVersions, false);
         }

--- a/src/Console/DeployParameters.cs
+++ b/src/Console/DeployParameters.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Cmf.CustomerPortal.Sdk.Console
+{
+    class DeployParameters
+    {
+
+        public bool Verbose { get; set; }
+        public string CustomerInfrastructureName { get; set; }
+        public string Name { get; set; }
+        public string AgentName { get; set; }
+        public string Description { get; set; }
+        public FileInfo Parameters { get; set; }
+        public string Type { get; set; }
+        public string Site { get; set; }
+        public string License { get; set; }
+        public string Package { get; set; }
+        public string Target { get; set; }
+        public string TemplateName { get; set; }
+        public DirectoryInfo Output { get; set; }
+        public string[] ReplaceTokens { get; set; }
+        public bool Interactive { get; set; }
+        public bool TerminateOtherVersions { get; set; }
+        public string Domain { get; set; }
+
+
+    }
+}

--- a/src/Console/Extensions/CommonParametersExtension.cs
+++ b/src/Console/Extensions/CommonParametersExtension.cs
@@ -12,9 +12,11 @@ namespace Cmf.CustomerPortal.Sdk.Console.Extensions
         {
             command.Add(new Option<string>(new[] { "--customer-infrastructure-name", "-ci", }, Resources.INFRASTRUCTURE_EXISTING_NAME_HELP));
 
-            command.Add(new Option<string>(new[] { "--name", "-n", }, Resources.DEPLOYMENT_NAME_HELP));
+            command.Add(new Option<string>(new[] {"--name", "-n", }, Resources.DEPLOYMENT_NAME_HELP));
+            
+            command.Add(new Option<string>(new[] { "--alias", "-a", }, Resources.DEPLOYMENT_ALIAS_HELP));
 
-            command.Add(new Option<string>(new[] { "--description", "-d", }, Resources.DEPLOYMENT_NAME_HELP));
+            command.Add(new Option<string>(new[] { "--description", "-d", }, Resources.DEPLOYMENT_DESCRIPTION_HELP));
 
             command.Add(new Option<FileInfo>(new string[] { "--parameters", "-params" }, Resources.DEPLOYMENT_PARAMETERSPATH_HELP)
             {

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -19,16 +19,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
             rootCommand.AddCommand(new PublishCommand());
             rootCommand.AddCommand(new PublishPackageCommand());
 
-            // cannot have an argument associated with --name with spaces. This condition is required to continue allowing users to have --name as a parameter
-            if (Array.IndexOf(args, "--name") > -1)
-            {
-                args[Array.IndexOf(args, "--name")] = "--id";
-            }
-           
-            
             return await rootCommand.InvokeAsync(args);
-
-           
         }
     }
 }

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.CommandLine;
 using System.Threading.Tasks;
 
@@ -17,9 +18,17 @@ namespace Cmf.CustomerPortal.Sdk.Console
             rootCommand.AddCommand(new LoginCommand());
             rootCommand.AddCommand(new PublishCommand());
             rootCommand.AddCommand(new PublishPackageCommand());
-           
 
+            // cannot have an argument associated with --name with spaces. This condition is required to continue allowing users to have --name as a parameter
+            if (Array.IndexOf(args, "--name") > -1)
+            {
+                args[Array.IndexOf(args, "--name")] = "--id";
+            }
+           
+            
             return await rootCommand.InvokeAsync(args);
+
+           
         }
     }
 }

--- a/src/Powershell/Extensions/CommonParametersExtension.cs
+++ b/src/Powershell/Extensions/CommonParametersExtension.cs
@@ -16,7 +16,7 @@ namespace Cmf.CustomerPortal.Sdk.Powershell.Extensions
             parameters = new List<RuntimeDefinedParameter>();
             parametersValue = new Dictionary<string, object>();
             CreateRuntimeParameter("CustomerInfrastructureName", Resources.INFRASTRUCTURE_EXISTING_NAME_HELP, typeof(string), true);
-            CreateRuntimeParameter("Name", Resources.DEPLOYMENT_NAME_HELP, typeof(string));
+            CreateRuntimeParameter("Name", Resources.DEPLOYMENT_NAME_HELP, typeof(string), true);
             CreateRuntimeParameter("Description", Resources.DEPLOYMENT_DESCRIPTION_HELP, typeof(string));
             CreateRuntimeParameter("ParametersPath", Resources.DEPLOYMENT_PARAMETERSPATH_HELP, typeof(FileInfo));
             CreateRuntimeParameter("EnvironmentType", Resources.DEPLOYMENT_ENVIRONMENTTYPE_HELP, typeof(EnvironmentType), defaultValue: EnvironmentType.Development);

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.3.3</Version>
+    <Version>1.3.4</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Changes**
- The System.CommandLine library has a logic that creates an alias every time it receives --name as an argument and it is not possible to have an alias with spaces. To work around this issue, --name was changed to --id and a condition was added to continue allowing the user to pass --name as an argument.
- An issue was created in Command Line api github repository (https://github.com/dotnet/command-line-api/issues/1705)