### PR TITLE
72705 - Portal SDK fails when installing a customer environment with spaces on the name - Reactivation

### DIFF
--- a/src/Common/Services/EnvironmentDeploymentHandler.cs
+++ b/src/Common/Services/EnvironmentDeploymentHandler.cs
@@ -95,6 +95,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
                             byte[] buffer = new byte[bytesToRead];
 
                             outputFile = Path.Combine(Path.GetTempPath(), downloadAttachmentOutput.FileName);
+                            outputFile = outputFile.Replace(" ", "").Replace("\"","");
                             _session.LogDebug($"Downloading to {outputFile}");
 
                             using (BinaryWriter streamWriter = new BinaryWriter(File.Open(outputFile, FileMode.Create, FileAccess.Write)))


### PR DESCRIPTION
**Changes**
- Remove spaces and " from directory. 