### PR TITLE
CustomerInfrastructure's InfrastructureAgent is no longer choosable during CustomerInfrastructure creation

### DIFF
--- a/src/Common/Handlers/NewInfrastructureFromTemplateHandler.cs
+++ b/src/Common/Handlers/NewInfrastructureFromTemplateHandler.cs
@@ -10,13 +10,13 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
     public class NewInfrastructureFromTemplateHandler : AbstractHandler
     {
         private readonly ICustomerPortalClient _customerPortalClient;
-        
+
         public NewInfrastructureFromTemplateHandler(ICustomerPortalClient customerPortalClient, ISession session) : base(session, true)
         {
             this._customerPortalClient = customerPortalClient;
         }
 
-        public async Task Run(string infrastructureName, string infrastructureTemplateName, string agentName)
+        public async Task Run(string infrastructureName, string infrastructureTemplateName)
         {
             await EnsureLogin();
 
@@ -41,7 +41,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
             if (customerInfrastructureTemplate.RelationCollection != null && customerInfrastructureTemplate.RelationCollection.Count > 0)
             {
                 customerInfrastructureTemplate.RelationCollection.TryGetValue(relationName, out EntityRelationCollection templatesRelations);
-                
+
                 if (templatesRelations?.Count > 0)
                 {
                     foreach (EntityRelation relation in templatesRelations)
@@ -57,7 +57,6 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
                 Name = customerInfrastructureName,
                 Customer = customerInfrastructureTemplate.Customer,
                 Domain = customerInfrastructureTemplate.Domain,
-                InfrastructureAgent = string.IsNullOrWhiteSpace(agentName) ? null : await _customerPortalClient.GetObjectByName<CustomerEnvironment>(agentName),
                 Parameters = customerInfrastructureTemplate.Parameters
             };
 

--- a/src/Common/Handlers/NewInfrastructureHandler.cs
+++ b/src/Common/Handlers/NewInfrastructureHandler.cs
@@ -10,13 +10,13 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
     public class NewInfrastructureHandler : AbstractHandler
     {
         private readonly ICustomerPortalClient _customerPortalClient;
-        
+
         public NewInfrastructureHandler(ICustomerPortalClient customerPortalClient, ISession session) : base(session, true)
         {
             this._customerPortalClient = customerPortalClient;
         }
 
-        public async Task Run(string infrastructureName, string agentName, string siteName, string customerName, string domain)
+        public async Task Run(string infrastructureName, string siteName, string customerName, string domain)
         {
             await EnsureLogin();
 
@@ -61,7 +61,6 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
                 Customer = customer,
                 Domain = domain,
                 //Parameters = @"{""SYSTEM_NAME"" : { ""Value"": ""xpto"" }}",
-                InfrastructureAgent = string.IsNullOrWhiteSpace(agentName) ? null : await _customerPortalClient.GetObjectByName<CustomerEnvironment>(agentName)
             };
 
             customerInfrastructure = (await new CreateCustomerInfrastructureInput

--- a/src/Common/Resources.cs
+++ b/src/Common/Resources.cs
@@ -18,7 +18,6 @@
         public const string DEPLOYMENT_TERMINATE_OTHER_VERSIONS_HELP = "Flag that controls if all the other versions of the Customer Environment should be terminated";
 
         public const string INFRASTRUCTUREFROMTEMPLATE_NAME_HELP = "The name of the Customer Infrastructure to be created";
-        public const string INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP = "The name of the Infrastructure Agent to be linked with the new Customer Infrastructure";
         public const string INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP = "The name of the Customer Infrastructure template that the new Customer Infrastructure will derive from";
         public const string INFRASTRUCTURE_SITE_HELP = "(deprecated) Name of a Site used to match a Customer with the Customer Infrastructure";
         public const string INFRASTRUCTURE_CUSTOMER_HELP = "Name of the Customer associated with the Customer Infrastructure";

--- a/src/Console/CreateInfrastructureCommand.cs
+++ b/src/Console/CreateInfrastructureCommand.cs
@@ -16,7 +16,6 @@ namespace Cmf.CustomerPortal.Sdk.Console
         public CreateInfrastructureCommand(string name, string description = null) : base(name, description)
         {
             Add(new Option<string>(new[] { "--name", "-n" }, Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP));
-            Add(new Option<string>(new[] { "--agent-name", "-a" }, Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP));
 
             Add(new Option<string>(new[] { "--site", "-s", }, Resources.INFRASTRUCTURE_SITE_HELP));
             Add(new Option<string>(new[] { "--customer", "-c", }, Resources.INFRASTRUCTURE_CUSTOMER_HELP));
@@ -34,7 +33,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
             // get new environment handler and run it
             CreateSession(parameters.Verbose);
             NewInfrastructureHandler handler = ServiceLocator.Get<NewInfrastructureHandler>();
-            await handler.Run(parameters.Name, parameters.AgentName, parameters.Site, parameters.Customer, parameters.Domain);
+            await handler.Run(parameters.Name, parameters.Site, parameters.Customer, parameters.Domain);
         }
     }
 }

--- a/src/Console/CreateInfrastructureFromTemplateCommand.cs
+++ b/src/Console/CreateInfrastructureFromTemplateCommand.cs
@@ -20,7 +20,6 @@ namespace Cmf.CustomerPortal.Sdk.Console
             {
                 IsRequired = true
             });
-            Add(new Option<string>(new[] { "--agent-name", "-a" }, Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP));
 
             Handler = CommandHandler.Create((DeployParameters x) => CreateInfrastructureFromTemplateHandler(x));
         }
@@ -30,7 +29,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
             // get new environment handler and run it
             CreateSession(parameters.Verbose);
             NewInfrastructureFromTemplateHandler newInfrastructureFromTemplateHandler = ServiceLocator.Get<NewInfrastructureFromTemplateHandler>();
-            await newInfrastructureFromTemplateHandler.Run(parameters.Name, parameters.TemplateName, parameters.AgentName);
+            await newInfrastructureFromTemplateHandler.Run(parameters.Name, parameters.TemplateName);
         }
     }
 }

--- a/src/Powershell/NewInfrastructure.cs
+++ b/src/Powershell/NewInfrastructure.cs
@@ -12,9 +12,6 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         [Parameter(HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_NAME_HELP)]
         public string Name { get; set; }
 
-        [Parameter(HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP)]
-        public string AgentName { get; set; }
-
         [Parameter(HelpMessage = Resources.INFRASTRUCTURE_SITE_HELP)]
         public string SiteName { get; set; }
 
@@ -28,7 +25,7 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         protected async override Task ProcessRecordAsync()
         {
             NewInfrastructureHandler handler = ServiceLocator.Get<NewInfrastructureHandler>();
-            await handler.Run(Name, AgentName, SiteName, CustomerName, Domain);
+            await handler.Run(Name, SiteName, CustomerName, Domain);
         }
     }
 }

--- a/src/Powershell/NewInfrastructureFromTemplate.cs
+++ b/src/Powershell/NewInfrastructureFromTemplate.cs
@@ -15,11 +15,6 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         public string Name { get; set; }
 
         [Parameter(
-            HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_AGENTNAME_HELP
-        )]
-        public string AgentName { get; set; }
-
-        [Parameter(
             HelpMessage = Resources.INFRASTRUCTUREFROMTEMPLATE_TEMPLATENAME_HELP,
             Mandatory = true
         )]
@@ -28,7 +23,7 @@ namespace Cmf.CustomerPortal.Sdk.Powershell
         protected async override Task ProcessRecordAsync()
         {
             NewInfrastructureFromTemplateHandler newInfrastructureFromTemplateHandler = ServiceLocator.Get<NewInfrastructureFromTemplateHandler>();
-            await newInfrastructureFromTemplateHandler.Run(Name, TemplateName, AgentName);
+            await newInfrastructureFromTemplateHandler.Run(Name, TemplateName);
         }
     }
 }


### PR DESCRIPTION
CustomerInfrastructure's InfrastructureAgent can no longer be previously created and assigned by name during CustomerInfrastructure creation or edition. It must be a two-step operation: the CustomerInfrastructure must be created without InfrastructureAgent, and then the InfrastructureAgent is created assigned to the existing CustomerInfrastructure.