### PR TITLE
83557 - Portal SDK fails when deploying the agent when creating new Infrastructure and Agents entities

### DIFF
--- a/src/Common/CustomerPortalClient.cs
+++ b/src/Common/CustomerPortalClient.cs
@@ -5,6 +5,7 @@ using Cmf.Foundation.BusinessOrchestration.ApplicationSettingManagement.InputObj
 using Cmf.Foundation.BusinessOrchestration.GenericServiceManagement.InputObjects;
 using Cmf.Foundation.BusinessOrchestration.QueryManagement.InputObjects;
 using Cmf.Foundation.Common.Base;
+using Cmf.Foundation.Security;
 using Cmf.LightBusinessObjects.Infrastructure;
 using Cmf.MessageBus.Client;
 using Newtonsoft.Json;
@@ -109,7 +110,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
         #endregion
 
         /// <summary>
-        /// Gets object by Id
+        /// Gets object by Name
         /// </summary>
         /// <typeparam name="T">The object type</typeparam>
         /// <param name="name">The object name</param>
@@ -341,6 +342,35 @@ namespace Cmf.CustomerPortal.Sdk.Common
             }
 
             return _transport;
+        }
+
+        /// <summary>
+        /// Gets object by Id
+        /// </summary>
+        /// <typeparam name="T">The object type</typeparam>
+        /// <param name="name">The object name</param>
+        /// <param name="levelsToLoad">Levels to Load</param>
+        /// <returns></returns>
+        public async Task<T> GetObjectById<T>(long id, int levelsToLoad = 0) where T : CoreBase, new()
+        {
+            var output = await new GetObjectByIdInput
+            {
+                Id = id ,
+                Type = typeof(T).BaseType.Name == typeof(CoreBase).Name ? new T() : (object)new T().GetType().Name,
+                LevelsToLoad = levelsToLoad
+            }.GetObjectByIdAsync(true);
+
+            return output.Instance as T;
+        }
+
+        /// <summary>
+        /// Get current user authenticated
+        /// </summary>
+        /// <returns>Current user</returns>
+        public async Task<User> GetCurrentUser()
+        {
+            var result = await new Foundation.BusinessOrchestration.ApplicationSettingManagement.InputObjects.GetApplicationBootInformationInput().GetApplicationBootInformationAsync(true);
+            return  result.User;
         }
     }
 }

--- a/src/Common/ICustomerPortalClient.cs
+++ b/src/Common/ICustomerPortalClient.cs
@@ -2,6 +2,7 @@
 using Cmf.Foundation.BusinessObjects;
 using Cmf.Foundation.BusinessObjects.QueryObject;
 using Cmf.Foundation.Common.Base;
+using Cmf.Foundation.Security;
 using Cmf.MessageBus.Client;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -62,5 +63,11 @@ namespace Cmf.CustomerPortal.Sdk.Common
         /// <param name="ids">Ids of the CustomerEnvironments</param>
         /// <returns>The collection of CustomerEnvironments with some properties filled.</returns>
         Task<CustomerEnvironmentCollection> GetCustomerEnvironmentsById(long[] ids);
+        Task<T> GetObjectById<T>(long id, int levelsToLoad = 0) where T : CoreBase, new();
+        /// <summary>
+        /// Get current user authenticated
+        /// </summary>
+        /// <returns>Current user</returns>
+        Task<User> GetCurrentUser();
     }
 }

--- a/src/Common/ICustomerPortalClient.cs
+++ b/src/Common/ICustomerPortalClient.cs
@@ -63,6 +63,14 @@ namespace Cmf.CustomerPortal.Sdk.Common
         /// <param name="ids">Ids of the CustomerEnvironments</param>
         /// <returns>The collection of CustomerEnvironments with some properties filled.</returns>
         Task<CustomerEnvironmentCollection> GetCustomerEnvironmentsById(long[] ids);
+
+        /// <summary>
+        /// Get's an object by its Id.
+        /// </summary>
+        /// <typeparam name="T">The object's Type</typeparam>
+        /// <param name="name">Name of the object</param>
+        /// <param name="levelsToLoad">Levels to load, defaulting to 0. More levels means more information and, therefore, a bigger payload.</param>
+        /// <returns>The loaded object</returns>
         Task<T> GetObjectById<T>(long id, int levelsToLoad = 0) where T : CoreBase, new();
         /// <summary>
         /// Get current user authenticated

--- a/src/Common/Services/InfrastructureCreationService.cs
+++ b/src/Common/Services/InfrastructureCreationService.cs
@@ -190,7 +190,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
             }
 
             // if we failed to wait for CustomerInfrastructure to be unlocked, throw an error
-             if (failedUnlock)
+            if (failedUnlock)
             {
                 Exception error = new Exception("Timed out waiting for CustomerInfrastructure be Created and Unlocked.");
                 session.LogError(error);

--- a/src/Common/Services/InfrastructureCreationService.cs
+++ b/src/Common/Services/InfrastructureCreationService.cs
@@ -1,8 +1,10 @@
 ﻿using Cmf.CustomerPortal.BusinessObjects;
 using Cmf.CustomerPortal.Orchestration.CustomerEnvironmentManagement.InputObjects;
+using Cmf.Foundation.Security;
 using Cmf.LightBusinessObjects.Infrastructure;
 using Cmf.LightBusinessObjects.Infrastructure.Errors;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -154,7 +156,29 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
                         {
                             await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationTokenSource.Token);
 
-                            customerInfrastructure = await customerPortalClient.GetObjectByName<CustomerInfrastructure>(customerInfrastructure.Name, 1);
+                            customerInfrastructure = await customerPortalClient.GetObjectById<CustomerInfrastructure>(customerInfrastructure.Id, 1);
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+            }
+
+            using (CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(_defaultSecondsTimeout))
+            {
+                failedUnlock = await Task.Run(async () =>
+                {
+                    User user = await customerPortalClient.GetCurrentUser();
+                    string roleName = $"CI - {customerInfrastructure.Customer.Name} - {customerInfrastructure.Name} - Owner";
+                    while (!user.Roles.Any(x => x.Name == roleName))
+                    {
+                        try
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(0.5), cancellationTokenSource.Token);
+                            user = await customerPortalClient.GetCurrentUser();
                         }
                         catch (TaskCanceledException)
                         {
@@ -166,7 +190,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
             }
 
             // if we failed to wait for CustomerInfrastructure to be unlocked, throw an error
-            if (failedUnlock)
+             if (failedUnlock)
             {
                 Exception error = new Exception("Timed out waiting for CustomerInfrastructure be Created and Unlocked.");
                 session.LogError(error);


### PR DESCRIPTION
**Changes**
- Check if infrastructure exists by id instead of by name.
- Check if infrastructure owner role is created after creating the infra. In case the role does not exist, an active wait is added. 