### PR TITLE
8500 - portal-sdk does not load all necessary information in infrastructure when it already exists

### DIFF
--- a/src/Common/Services/InfrastructureCreationService.cs
+++ b/src/Common/Services/InfrastructureCreationService.cs
@@ -64,7 +64,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
             try
             {
                 session.LogInformation($"Checking if exists the current Customer Infrastructure with name '{customerInfrastructureName}'.");
-                currentCustomerInfrastructure = await customerPortalClient.GetObjectByName<CustomerInfrastructure>(customerInfrastructureName);
+                currentCustomerInfrastructure = await customerPortalClient.GetObjectByName<CustomerInfrastructure>(customerInfrastructureName, 1);
                 session.LogInformation($"Customer Infrastructure with name '{customerInfrastructureName}' exists.");
             }
             catch (CmfFaultException ex) when (ex.Code?.Name == Foundation.Common.CmfExceptionType.Db20001.ToString())

--- a/src/Common/Services/InfrastructureCreationService.cs
+++ b/src/Common/Services/InfrastructureCreationService.cs
@@ -64,6 +64,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
             try
             {
                 session.LogInformation($"Checking if exists the current Customer Infrastructure with name '{customerInfrastructureName}'.");
+                // levelsToLoad  = 1, because the customer name is necessary to get the role later  
                 currentCustomerInfrastructure = await customerPortalClient.GetObjectByName<CustomerInfrastructure>(customerInfrastructureName, 1);
                 session.LogInformation($"Customer Infrastructure with name '{customerInfrastructureName}' exists.");
             }

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.10.0</Version>
+    <Version>1.10.1</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Changes**
- Change levelsToLoad in GetObjectByName when loading an infrastructure because with levelsToLoad equal to 0 the client is not loaded.