### PR TITLE
74130 - Fix terminate other versions

### DIFF
--- a/src/Common/CustomerPortalClient.cs
+++ b/src/Common/CustomerPortalClient.cs
@@ -147,13 +147,14 @@ namespace Cmf.CustomerPortal.Sdk.Common
             }.ExecuteQueryAsync(true)).NgpDataSet);
         }
 
-        public async Task<T> TerminateObjects<T, U>(T obj, OperationAttributeCollection operationAttributes = null) where T : List<U>, new() where U : new()
+        public async Task<T> TerminateObjects<T, U>(T obj, OperationAttributeCollection operationAttributes = null, bool isToTerminateAllVersions = false) where T : List<U>, new() where U : new()
         {
             return (await new TerminateObjectsInput
             {
                 Objects = new Collection<object>(obj.ConvertAll(x => x as object)),
                 OperationAttributes = operationAttributes,
-                IgnoreLastServiceId = true
+                IgnoreLastServiceId = true,
+                OperationTarget = isToTerminateAllVersions ? EntityTypeSource.Revision : EntityTypeSource.Version
             }.TerminateObjectsAsync(true)).Objects as T;
         }
 

--- a/src/Common/ICustomerPortalClient.cs
+++ b/src/Common/ICustomerPortalClient.cs
@@ -55,7 +55,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
         /// <param name="obj">The list of objects</param>
         /// <param name="operationAttributes">Operation attributes to pass to the service</param>
         /// <returns>The same list of objects</returns>
-        Task<T> TerminateObjects<T, U>(T obj, OperationAttributeCollection operationAttributes = null) where T : List<U>, new() where U : new();
+        Task<T> TerminateObjects<T, U>(T obj, OperationAttributeCollection operationAttributes = null, bool isToTerminateAllVersions = false) where T : List<U>, new() where U : new();
 
         /// <summary>
         /// Gets a collection of CustomerEnvironments.

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.1</Version>
+    <Version>1.13.2</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
**Changes**
- Fix terminate other versions. With no operation target, TerminateObjects service terminates objects at the revision level by default. 