### PR TITLE
fix(): use release tag in install.js script instead of app version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,6 +67,9 @@ jobs:
       # Replace Version token on NPM package.json
       - name: Replace package.json Version token
         run: cd npm && sed -i ''s/#{Version}#/${{ steps.getver.outputs.result }}/g'' package.json
+      # Replace Version token on NPM install.js
+      - name: Replace install.js Version token
+        run: cd npm && sed -i ''s/#{Version}#/${{ github.ref_name }}/g'' install.js
       # Setup Node.js environment
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.4.1

--- a/npm/install.js
+++ b/npm/install.js
@@ -38,7 +38,7 @@ fs.unlink(path.join(installScriptLocation, 'cmf-portal'), (err) => {
 
 // download respective release zip from github
 console.info(`Current platform / arch: ${process.platform} / ${process.arch}`);
-const pkgUrl = `https://github.com/criticalmanufacturing/portal-sdk/releases/download/${process.env.npm_package_version}/Cmf.CustomerPortal.Sdk.Console-${process.env.npm_package_version}.${PLATFORM_MAPPING[process.platform]}-${ARCH_MAPPING[process.arch]}.zip`;// opts.binUrl.replace("{{version}}", opts.version).replace("{{platform}}", PLATFORM_MAPPING[process.platform]).replace("{{arch}}", ARCH_MAPPING[process.arch]);
+const pkgUrl = `https://github.com/criticalmanufacturing/portal-sdk/releases/download/#{Version}#/Cmf.CustomerPortal.Sdk.Console-${process.env.npm_package_version}.${PLATFORM_MAPPING[process.platform]}-${ARCH_MAPPING[process.arch]}.zip`;// opts.binUrl.replace("{{version}}", opts.version).replace("{{platform}}", PLATFORM_MAPPING[process.platform]).replace("{{arch}}", ARCH_MAPPING[process.arch]);
 console.info(`Getting release archive from ${pkgUrl} into ${path.resolve(installScriptLocation)}`);
 axios.get(pkgUrl, { responseType: 'arraybuffer' })
      .then(function (response) {


### PR DESCRIPTION
Changed git hub release action to provide the release tag to the install.js script, in order for it to download the artifact from the correct url.