### PR TITLE
feat(): upgrade portal sdk to use .net 8 #98231

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       # Run build
       - name: Build Windows
         env:
@@ -45,14 +45,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64
-          path: src/Console/bin/Release/netcoreapp3.1/win-x64/publish/
+          path: src/Console/bin/Release/net8.0/win-x64/publish/
       - name: Archive Console Linux64
         uses: actions/upload-artifact@v2
         with:
           name: Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.linux-x64
-          path: src/Console/bin/Release/netcoreapp3.1/linux-x64/publish/
+          path: src/Console/bin/Release/net8.0/linux-x64/publish/
       - name: Archive PowerShell
         uses: actions/upload-artifact@v2
         with:
           name: Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}
-          path: src/Powershell/bin/Release/netstandard2.0/linux-x64/publish/
+          path: src/Powershell/bin/Release/net8.0/linux-x64/publish/

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -1,24 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Cmf.CustomerPortal.Sdk.Common</AssemblyName>
     <RootNamespace>Cmf.CustomerPortal.Sdk.Common</RootNamespace>
   </PropertyGroup>
-
   <Import Project="..\Version.props" />
   <ItemGroup>
     <None Include="..\Version.props" Link="Version.props" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Cmf.LightBusinessObjects">
       <HintPath>libs\Cmf.LightBusinessObjects.dll</HintPath>
@@ -35,15 +31,8 @@
     <Reference Include="SuperSocket.ClientEngine">
       <HintPath>libs\SuperSocket.ClientEngine.dll</HintPath>
     </Reference>
-    <Reference Include="System.Configuration.ConfigurationManager">
-      <HintPath>libs\System.Configuration.ConfigurationManager.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting">
-      <HintPath>libs\System.Net.Http.Formatting.dll</HintPath>
-    </Reference>
     <Reference Include="WebSocket4Net">
       <HintPath>libs\WebSocket4Net.dll</HintPath>
     </Reference>
   </ItemGroup>
-
 </Project>

--- a/src/Common/Services/Utilities.cs
+++ b/src/Common/Services/Utilities.cs
@@ -46,7 +46,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
                 }
                 else
                 {
-                    throw e;
+                    throw;
                 }
             }
         }

--- a/src/Console/Console.csproj
+++ b/src/Console/Console.csproj
@@ -1,35 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>cmf-portal</AssemblyName>
     <RootNamespace>Cmf.CustomerPortal.Sdk.Console</RootNamespace>
   </PropertyGroup>
-
   <Import Project="..\Version.props" />
   <ItemGroup>
     <None Include="..\Version.props" Link="Version.props" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Cmf.LightBusinessObjects">
       <HintPath>..\Common\libs\Cmf.LightBusinessObjects.dll</HintPath>
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Console/Properties/launchSettings.json
+++ b/src/Console/Properties/launchSettings.json
@@ -31,6 +31,10 @@
     "publish package": {
       "commandName": "Project",
       "commandLineArgs": "publish-package --path \"C:\\packages\" --datagroup \"\" --verbose"
+    },
+    "Check Agent Connection": {
+      "commandName": "Project",
+      "commandLineArgs": "checkagentconnection -n \"sdkTestInfra\""
     }
   }
 }

--- a/src/Powershell/Powershell.csproj
+++ b/src/Powershell/Powershell.csproj
@@ -1,35 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Cmf.CustomerPortal.Sdk.Powershell</AssemblyName>
     <RootNamespace>Cmf.CustomerPortal.Sdk.Powershell</RootNamespace>
   </PropertyGroup>
-
   <Import Project="..\Version.props" />
   <ItemGroup>
     <None Include="..\Version.props" Link="Version.props" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="Cmf.LightBusinessObjects">
       <HintPath>..\Common\libs\Cmf.LightBusinessObjects.dll</HintPath>
     </Reference>
   </ItemGroup>
-
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
## What was done
* Upgrades the version of .net to .net 8 in all projects of the solution.
* Alters the build to fetch the artifacts from the different path

## How was this tested?
* Manually validated by running:
1. cmf-portal login
2. cmf-portal checkagentconnection