### PR TITLE
feat(): Read cm portal token from env var

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,42 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Login",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Console/bin/Debug/net8.0/cmf-portal.dll",
+            "args": [
+                "login",
+                "--verbose"
+            ],
+            "cwd": "${workspaceFolder}/src/Console",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "CheckAgentConnection",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/Console/bin/Debug/net8.0/cmf-portal.dll",
+            "args": [
+                "checkagentconnection",
+                "-n", "myagent123",
+                "--verbose"
+            ],
+            "env": {
+                "CM_PORTAL_TOKEN": ""
+            },
+            "cwd": "${workspaceFolder}/src/Console",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
             // Use IntelliSense to find out which attributes exist for C# debugging
             // Use hover for the description of the existing attributes
             // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
@@ -10,7 +46,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Console/bin/Debug/netcoreapp3.1/cmf-portal.dll",
+            "program": "${workspaceFolder}/src/Console/bin/Debug/net8.0/cmf-portal.dll",
             "args": [
                 "install-app",
                 "-n", "",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # portal-sdk
-Customer Portal SDK that allows the creation of automation script for integration with CMF DevOps Center
+Customer Portal SDK that allows the creation of automation script for integration with CM DevOps Center.
 
 # Pre-Requisites
 Make sure to run the Powershell Cmdlets from in Powershell Core 7.1.3 or above.
@@ -10,7 +10,9 @@ The Customer Portal SDK has 2 versions that can be used:
  - <a href="#console">```Console```</a> - this version works as a standalone executable. To use it run the executable in a console or powershell with the appropriate commands.
  - <a href="#powershell">```Powershell```</a> - this version compiles into a DLL with a cmdlet for each command. To use it, import the DLL into a powershell and then call the desired cmdlet. 
 
-**Important:** You need to authenticate before running other commands/cmdlets. The command is ```login``` and the cmdlet is ```Set-Login```.
+**Important:** You need to authenticate before running other commands/cmdlets. There are two ways to achieve this:
+1. Provide a ```CM_PORTAL_TOKEN``` environment variable - variable read from the system where the application is run.
+1. Explicit login operation - login using a PAT as a parameter or in an interactive way if none is provided. **This alternative caches the Auth Token in a file** on the host filesystem, under _{AppDataFolder}/cmfportal/cmfportaltoken_. The command is ```login``` and the cmdlet is ```Set-Login```.
 
 You can get the tool from the Releases section in GitHub, from npm using ```npm install @criticalmanufacturing/portal --global``` or by compiling the source code manually.
 
@@ -42,7 +44,7 @@ Commands:
   - <a href="#deployagent">```deployagent```</a> - Creates and deploys a new Infrastructure Agent
   - <a href="#deploy">```deploy```</a> - Creates and deploys a new Customer Environment
   - <a href="#install-app">```install-app```</a> - Installs an App in a previous deployed Convergence Customer Environment
-  - <a href="#login">```login```</a> - Log in to the CMF Portal
+  - <a href="#login">```login```</a> - Log in to the CM Portal
   - <a href="#publish">```publish```</a> - Publishes one or more Deployment Manifests into Customer Portal
   - <a href="#publish-package">```publish-package```</a> - Publishes one or more Customization Packages into Customer Portal
 
@@ -162,7 +164,7 @@ Options:
 
 ### login
 
-Log in to the CMF Portal
+Log in to the CM Portal. This command will cache the Auth Token to a file in the host filesystem. 
 
 Equivalent to powershell cmdlet <a href="#set-login">Set-Login</a>
 
@@ -225,7 +227,7 @@ Cmdlets:
   - <a href="#new-environment">```New-Environment```</a> - Creates and deploys a new Customer Environment
   - <a href="#new-infrastructure">```New-Infrastructure```</a> - Creates a customer Infrastructure
   - <a href="#new-infrastructureagent">```New-InfrastructureAgent```</a> - Creates and deploys a new Infrastructure Agent
-  - <a href="#set-login">```Set-Login```</a> - Log in to the CMF Portal
+  - <a href="#set-login">```Set-Login```</a> - Log in to the CM Portal
 
 
 Examples:
@@ -338,7 +340,7 @@ Options:
 
 ### Set-Login
 
-Log in to the CMF Portal
+Log in to the CM Portal. This command will cache the Auth Token to a file in the host filesystem. 
 
 Equivalent to the console command <a href="#login">login</a>
 

--- a/src/Common/ISession.cs
+++ b/src/Common/ISession.cs
@@ -8,7 +8,6 @@ namespace Cmf.CustomerPortal.Sdk.Common
     {
         IConfiguration Configuration { get; set; }
         LogLevel LogLevel { get; }
-        string AccessToken { get; }
         void ConfigureSession(string token = null);
         void RestoreSession();
 


### PR DESCRIPTION
# Changelog:
* Support reading the CM Portal token from an environment variable "CM_PORTAL_TOKEN".
  * If the environment variable has a non-empty and non-whitespace value, it is cached in memory only and not in file. It will be used for requests to the CM Portal.
  * Otherwise, the application behaves as if no token exists and each command that requires a valid login will throw an error if the login wasn't performed.

**Note**: If the login command is run, the environment variable is not taken into account since this command is used to explicitly save the token passed as an option or fetched from the interactive login. In this case, the token is still cached to a file as it was.