### PR TITLE
fix(): Release workflow not supporting net8 and missing version bump

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       # Run build
       - name: Build Windows
         env:
@@ -38,13 +38,13 @@ jobs:
       # Generate packs
       - name: Archive Console Win64
         run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.win-x64.zip .
-        working-directory: src/Console/bin/Release/netcoreapp3.1/win-x64/publish/
+        working-directory: src/Console/bin/Release/net8.0/win-x64/publish/
       - name: Archive Console Linux64
         run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.Console-${{ steps.getver.outputs.result }}.linux-x64.zip .
-        working-directory: src/Console/bin/Release/netcoreapp3.1/linux-x64/publish/
+        working-directory: src/Console/bin/Release/net8.0/linux-x64/publish/
       - name: Archive PowerShell
         run: zip -X -r ../../../../../../../Cmf.CustomerPortal.Sdk.PowerShell-${{ steps.getver.outputs.result }}.zip .
-        working-directory: src/Powershell/bin/Release/netstandard2.0/linux-x64/publish/
+        working-directory: src/Powershell/bin/Release/net8.0/linux-x64/publish/
       # Add to release assets
       - name: Add Console Win64 to Release assets
         uses: JasonEtco/upload-to-release@master

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.8</Version>
+    <Version>1.13.9</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Changelog
* Updated the npm-publish github workflow to target net8.
* Version bump to 1.13.9