### PR TITLE
fix(): keep original permissions when extracting the zip

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -47,12 +47,12 @@ axios.get(pkgUrl, { responseType: 'arraybuffer' })
          console.log(`Writing temporary zip file to ${zip}`);
          fs.writeFileSync(zip, response.data);
          console.log(`Extracting zip file ${zip} to ${installScriptLocation}`);
-         (new AdmZip(zip)).extractAllTo(installScriptLocation);
+         (new AdmZip(zip)).extractAllTo(installScriptLocation, undefined, true);
          rimraf.sync(zip)
      })
      .catch(function (error) {
          // handle error
          console.error(error);
-         console.error(error(`Could not install version ${process.env.npm_package_version} on your platform ${process.platform}/${process.arch}: ${e.message}`));
+         console.error(error(`Could not install version ${process.env.npm_package_version} on your platform ${process.platform}/${process.arch}: ${error.message}`));
          process.exit(1);
      });

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.9</Version>
+    <Version>1.13.10</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Issue
In linux, after the install.js is run, the extracted release does not have execute permissions on the cmf-portal binary, preventing its usage.

# What was done
1. When extracting the zip file, prevent the extract process from changing the original permissions of the content. It was noted that, when the release was built, the binary had `rwx` perms, which means that we just need to maintain those.
2. Fixed an issue, in case of an error when downloading the release package, that the error variable `error` was being used as `e`, causing a syntax error.