### PR TITLE
fix(): prevent TerminationFailed environments to be terminated

### DIFF
--- a/src/Common/Services/NewEnvironmentUtilities.cs
+++ b/src/Common/Services/NewEnvironmentUtilities.cs
@@ -86,8 +86,7 @@ namespace Cmf.CustomerPortal.Sdk.Common.Services
 						(int)DeploymentStatus.NotDeployed,
 						(int)DeploymentStatus.DeploymentFailed,
 						(int)DeploymentStatus.DeploymentPartiallySucceeded,
-						(int)DeploymentStatus.DeploymentSucceeded,
-						(int)DeploymentStatus.TerminationFailed
+						(int)DeploymentStatus.DeploymentSucceeded
 					},
 					LogicalOperator = Cmf.Foundation.Common.LogicalOperator.AND,
 					FilterType = Cmf.Foundation.BusinessObjects.QueryObject.Enums.FilterType.Normal,

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.13.10</Version>
+    <Version>1.13.11</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# What's Changed
Prevent the portal-sdk from getting CustomerEnvironments that are in Status TerminationFailed (and UniversalState Created) to be terminated. TerminationFailed environments should always be in UniversalState Terminated state as well and, if that isn't the case, they should remain in that inconsistent status so that we can investigate the issue behind it.

## Changelog
* Removed TerminationFailed from DeploymentStatus Query Filter