### PR TITLE
Fixed GetLicenseByUniqueName for PowerShell environment

### DIFF
--- a/src/Common/Utils.cs
+++ b/src/Common/Utils.cs
@@ -117,7 +117,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
                 Type = Activator.CreateInstance<CPSoftwareLicense>()
             };
 
-            GetObjectsByFilterOutput gobfOutput = gobfiInput.GetObjectsByFilterAsync(true).Result;
+            GetObjectsByFilterOutput gobfOutput = await gobfiInput.GetObjectsByFilterAsync(true);
 
             if (gobfOutput.Instance.Count == 0)
             {

--- a/src/Common/Utils.cs
+++ b/src/Common/Utils.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Cmf.CustomerPortal.BusinessObjects;
 using Cmf.Foundation.BusinessObjects.QueryObject;
 using Cmf.Foundation.BusinessOrchestration.GenericServiceManagement.InputObjects;
+using Cmf.Foundation.BusinessOrchestration.GenericServiceManagement.OutputObjects;
 using Cmf.Foundation.Common;
 
 namespace Cmf.CustomerPortal.Sdk.Common
@@ -116,7 +117,14 @@ namespace Cmf.CustomerPortal.Sdk.Common
                 Type = Activator.CreateInstance<CPSoftwareLicense>()
             };
 
-            return (CPSoftwareLicense)gobfiInput.GetObjectsByFilterSync().Instance[0];
+            GetObjectsByFilterOutput gobfOutput = gobfiInput.GetObjectsByFilterAsync(true).Result;
+
+            if (gobfOutput.Instance.Count == 0)
+            {
+                throw new Exception($"License with name {licenseUniqueName} does not exist");
+            }
+
+            return (CPSoftwareLicense)gobfOutput.Instance[0];
         }
     }
 }

--- a/src/Common/Utils.cs
+++ b/src/Common/Utils.cs
@@ -108,6 +108,13 @@ namespace Cmf.CustomerPortal.Sdk.Common
                     LogicalOperator = LogicalOperator.AND,
                     Operator = FieldOperator.IsEqualTo,
                     Value = licenseUniqueName
+                },
+                new Filter() // exclude Definition or Revision results
+                {
+                    Name = "Version",
+                    LogicalOperator= LogicalOperator.AND,
+                    Operator= FieldOperator.GreaterThan,
+                    Value = 0
                 }
             };
 
@@ -122,6 +129,11 @@ namespace Cmf.CustomerPortal.Sdk.Common
             if (gobfOutput.Instance.Count == 0)
             {
                 throw new Exception($"License with name {licenseUniqueName} does not exist");
+            }
+            
+            if (gobfOutput.Instance.Count > 1)
+            {
+                throw new Exception($"Too many matches for license {licenseUniqueName}");
             }
 
             return (CPSoftwareLicense)gobfOutput.Instance[0];

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.8</Version>
+    <Version>1.14.9</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixed GetLicenseByUniqueName for PowerShell environment.
Also throws exception if license is not found.