### PR TITLE
chore: create ApplicationData folder if not exists

### DIFF
--- a/src/Common/CmfPortalSession.cs
+++ b/src/Common/CmfPortalSession.cs
@@ -12,7 +12,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
         private const string _cmfPortalDirName = "cmfportal";
         private const string _loginTokenFileName = "cmfportaltoken";
         private const string _tokenEnvVar = "CM_PORTAL_TOKEN";
-        private static readonly string _loginCredentialsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), _cmfPortalDirName);
+        private static readonly string _loginCredentialsDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), _cmfPortalDirName);
         private static readonly string _loginCredentialsFilePath = Path.Combine(_loginCredentialsDir, _loginTokenFileName);
         
         private string token = null;

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.13</Version>
+    <Version>1.14.14</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR solves the scenario (for now only seen in linux) when the ApplicationData folder doesn't exists:
![image](https://github.com/user-attachments/assets/34043946-ac4e-4901-90f5-8808d5ad9157)

before:
![image](https://github.com/user-attachments/assets/bda254c3-a0d6-46ee-9223-ccfac2c0204a)

after:
![image](https://github.com/user-attachments/assets/ac29595a-fe44-448b-bc50-f2df2b02871c)
