### PR TITLE
fix(): portal-sdk binary download not working through a proxy

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -5,7 +5,9 @@
 const path = require('path'),
       fs = require('fs'),
       axios = require('axios'),
-      proxyAgent = require('proxy-agent'),
+      httpsProxyAgent = require('https-proxy-agent'),
+      httpProxyAgent = require('http-proxy-agent'),
+      proxyFromEnv = require('proxy-from-env'),
       AdmZip = require("adm-zip"),
       tmp = require('tmp'),
       rimraf = require('rimraf'),
@@ -42,10 +44,16 @@ async function downloadAndExtract(pkgUrl) {
     try {
         console.info(`Fetching release archive from ${pkgUrl}`);
 
-        // support for http proxies through env vars
-        const agent = new proxyAgent.ProxyAgent();
+        // support for http/s proxies through env vars
+        const proxy = proxyFromEnv.getProxyForUrl(pkgUrl);
+        let httpAgent, httpsAgent;
+        if (proxy) {
+            httpAgent = new httpProxyAgent.HttpProxyAgent(proxy);
+            httpsAgent = new httpsProxyAgent.HttpsProxyAgent(proxy);
+        }
 
-        const response = await axios.get(pkgUrl, { httpAgent: agent.httpAgent, httpsAgent: agent.httpsAgent, proxy: false, responseType: 'arraybuffer' });
+        // make req (override axios automatic proxy since it is not working properly)
+        const response = await axios.get(pkgUrl, { httpAgent: httpAgent, httpsAgent: httpsAgent, proxy: false, responseType: 'arraybuffer' });
         
         const zip = tmp.tmpNameSync();
         console.log(`Writing temporary zip file to ${zip}`);

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,6 +5,7 @@
 const path = require('path'),
       fs = require('fs'),
       axios = require('axios'),
+      proxyAgent = require('proxy-agent'),
       AdmZip = require("adm-zip"),
       tmp = require('tmp'),
       rimraf = require('rimraf'),
@@ -40,7 +41,11 @@ fs.unlink(path.join(installScriptLocation, 'cmf-portal'), (err) => {
 async function downloadAndExtract(pkgUrl) {
     try {
         console.info(`Fetching release archive from ${pkgUrl}`);
-        const response = await axios.get(pkgUrl, { responseType: 'arraybuffer' });
+
+        // support for http proxies through env vars
+        const agent = new proxyAgent.ProxyAgent();
+
+        const response = await axios.get(pkgUrl, { httpAgent: agent.httpAgent, httpsAgent: agent.httpsAgent, proxy: false, responseType: 'arraybuffer' });
         
         const zip = tmp.tmpNameSync();
         console.log(`Writing temporary zip file to ${zip}`);

--- a/npm/package.json
+++ b/npm/package.json
@@ -31,7 +31,8 @@
     ],
     "dependencies": {
         "adm-zip": "^0.5.5",
-        "axios": "^0.21.1",
+        "proxy-agent": "^6.5.0",
+        "axios": "^1.7.9",
         "node_modules-path": "^2.0.5",
         "rimraf": "^3.0.2",
         "tmp": "0.2.1"

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.15</Version>
+    <Version>1.14.16</Version>
   </PropertyGroup>
 </Project>

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.16</Version>
+    <Version>1.14.17</Version>
   </PropertyGroup>
 </Project>

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.17</Version>
+    <Version>1.14.18</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# What's Changed
The request to download the portal-sdk binary, through `axios`, is not working. It **may** be related with this [issue](https://github.com/axios/axios/issues/4533).

A work-around that seems to work is to send the `httpAgent` and `httpsAgent` ourselves, through the `proxy-agent` (which is the one that axios also uses) and disabling its internal proxy configuration.

This was validated in a Microshift VM, through a proxy.

Test on a pwsh window with proxy:
![image](https://github.com/user-attachments/assets/33aa68e6-17ab-45e5-8e0d-e1b3e603f49f)
