### PR TITLE
fix(): Downgrade proxy agent version to support node 12

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -31,7 +31,7 @@
     ],
     "dependencies": {
         "adm-zip": "^0.5.5",
-        "proxy-agent": "^6.5.0",
+        "proxy-agent": "^5.0.0",
         "axios": "^1.7.9",
         "node_modules-path": "^2.0.5",
         "rimraf": "^3.0.2",

--- a/src/Version.props
+++ b/src/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.14.18</Version>
+    <Version>1.14.19</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# What's Changed
Downgraded the required `proxy-agent` dependency from `^6.5.0` to `^5.0.0` to support Node 12.
Unfortunately, it includes some vulnerabilities but there's no way to fix since there are packages dependencies mismatches. However, this is only required for 2 more months, which is the end-of-life for MES v8 LTS.

Tests:
With current package.json and node 12.22.12:
![image](https://github.com/user-attachments/assets/b1ff9ec3-8b26-4ba1-abec-d5571e42b8e0)


With newer package.json and node 12.22.12:
![image](https://github.com/user-attachments/assets/9d75c152-c9f7-4971-979f-00e1fd548c6f)
![image](https://github.com/user-attachments/assets/bcc60194-df84-40f5-9818-e89e4dffc28e)
