### PR TITLE
Create environment and send DP and Licence as relation

### DIFF
--- a/src/Common/Handlers/NewEnvironmentHandler.cs
+++ b/src/Common/Handlers/NewEnvironmentHandler.cs
@@ -98,8 +98,11 @@ namespace Cmf.CustomerPortal.Sdk.Common.Handlers
                 var cedpCollection = new CustomerEnvironmentDeploymentPackageCollection();
                 if (isInfrastructureAgent || string.IsNullOrWhiteSpace(deploymentPackageName))
                 {
-                    cedpCollection.AddRange(environment.RelationCollection.FirstOrDefault(x => x.Key == nameof(CustomerEnvironmentDeploymentPackage)).Value
-                                                                            .Cast<CustomerEnvironmentDeploymentPackage>());
+                    var currentRelations = environment.RelationCollection.FirstOrDefault(x => x.Key == nameof(CustomerEnvironmentDeploymentPackage)).Value?.Cast<CustomerEnvironmentDeploymentPackage>();
+                    if(currentRelations is not null && currentRelations.Count() > 0)
+                    {
+                        cedpCollection.AddRange(currentRelations);
+                    }                    
                 }
                 else
                 {


### PR DESCRIPTION
# What was done

Instead of filling the "DeploymentPackage" and the "SoftwareLicense", send that data as a "Relation" in the requests.

# How to test

Create a customer environment using the PortalSDK
Create a customer environment in a infrastructure using PortalSDK
Create a new version of a customer environment using PortalSDK
Other relevant tests