### PR TITLE
feat: add print token command

### DIFF
--- a/src/Common/CmfPortalSession.cs
+++ b/src/Common/CmfPortalSession.cs
@@ -134,6 +134,15 @@ namespace Cmf.CustomerPortal.Sdk.Common
             ConfigureLBOs(token);
         }
 
+        /// <summary>
+        /// Prints the current session token to the console.
+        /// </summary>
+        public void PrintSessionToken()
+        {
+            RestoreSession();
+            LogInformation(Token);
+        }
+
         public abstract void LogDebug(string message);
         public abstract void LogError(string message);
         public abstract void LogError(Exception exception);

--- a/src/Common/CommonModule.cs
+++ b/src/Common/CommonModule.cs
@@ -26,6 +26,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
             serviceCollection.AddTransient<Handlers.PublishPackageHandler>();
             serviceCollection.AddTransient<Handlers.InstallAppHandler>();
             serviceCollection.AddTransient<Handlers.DownloadArtifactsHandler>();
+            serviceCollection.AddTransient<Handlers.TokenHandler>();
         }
     }
 }

--- a/src/Common/Handlers/TokenHandler.cs
+++ b/src/Common/Handlers/TokenHandler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Cmf.CustomerPortal.Sdk.Common.Handlers
+{
+    public class TokenHandler : AbstractHandler
+    {
+        public TokenHandler(ISession session) : base(session, true) { }
+
+        public async override Task Run()
+        {
+            await EnsureLogin();
+
+            Session.PrintSessionToken();
+        }
+    }
+}

--- a/src/Common/ISession.cs
+++ b/src/Common/ISession.cs
@@ -10,6 +10,7 @@ namespace Cmf.CustomerPortal.Sdk.Common
         LogLevel LogLevel { get; }
         void ConfigureSession(string token = null);
         void RestoreSession();
+        void PrintSessionToken();
 
         void LogInformation(string message);
         void LogError(string message);

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -18,6 +18,7 @@ namespace Cmf.CustomerPortal.Sdk.Console
             rootCommand.AddCommand(new LoginCommand());
             rootCommand.AddCommand(new PublishCommand());
             rootCommand.AddCommand(new PublishPackageCommand());
+            rootCommand.AddCommand(new TokenCommand());
 
             return await rootCommand.InvokeAsync(args);
         }

--- a/src/Console/TokenCommand.cs
+++ b/src/Console/TokenCommand.cs
@@ -1,0 +1,27 @@
+﻿using Cmf.CustomerPortal.Sdk.Common.Handlers;
+using Cmf.CustomerPortal.Sdk.Console.Base;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+
+namespace Cmf.CustomerPortal.Sdk.Console
+{
+    class TokenCommand : BaseCommand
+    {
+        public TokenCommand() : this("token", "Print the authentication token of the CMF Portal")
+        {
+        }
+
+        public TokenCommand(string name, string description = null) : base(name, description)
+        {
+            Handler = CommandHandler.Create(typeof(TokenCommand).GetMethod(nameof(TokenCommand.TokenHandler)), this);
+        }
+
+        public async Task TokenHandler(bool verbose)
+        {
+            // use token handler to print the token information
+            CreateSession(verbose);
+            TokenHandler tokenHandler = ServiceLocator.Get<TokenHandler>();
+            await tokenHandler.Run();
+        }
+    }
+}


### PR DESCRIPTION
Similar to what the `gh` CLI provides with `gh auth token` command.
This could simplify having an environment variable with:

```
export CM_PORTAL_TOKEN=$(cmf-portal token)
```